### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-jcbyaxdu/overlays/prod/deployment-patch.yaml
+++ b/components/go-jcbyaxdu/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-jcbyaxdu:github-7da19cab5716a378c0c34890bb60509e2c605ed2
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-jcbyaxdu:github-7da19cab5716a378c0c34890bb60509e2c605ed2